### PR TITLE
Fix tipo on Math.random()

### DIFF
--- a/02_Day_Data_types/02_day_data_types.md
+++ b/02_Day_Data_types/02_day_data_types.md
@@ -210,7 +210,7 @@ console.log(randNum)
 
 // Let us  create random number between 0 to 10
 
-const num = Math.floor(Math.random () * 11) // creates random number between 0 and 10
+const num = Math.floor(Math.random () * 10) // creates random number between 0 and 10
 console.log(num)
 
 //Absolute value
@@ -247,7 +247,7 @@ The JavaScript Math Object has a random() method number generator which generate
 let randomNum = Math.random() // generates 0 to 0.999...
 ```
 
-Now, let us see how we can use random() method to generate a random number between 0 and 10:
+Now, let us see how we can use random() method to generate a random number between 0 and 11:
 
 ```js
 let randomNum = Math.random()         // generates 0 to 0.999


### PR DESCRIPTION
This small Pull request, it's about to fix , I guess a tipo on `Math.random()`. On day 2, it's say generate random between 0 and 10, then the result can be 10,333 of course. But 10,33 it's not between 0 et 10, but 11. 
Same for previous description.