### PR TITLE
fixing incorrect variable name: numInt -> numFloat

### DIFF
--- a/02_Day_Data_types/02_day_data_types.md
+++ b/02_Day_Data_types/02_day_data_types.md
@@ -876,7 +876,7 @@ console.log(numFloat) // 9.81
 let num = '9.81'
 let numFloat = +num
 
-console.log(numInt) // 9.81
+console.log(numFloat) // 9.81
 ```
 
 #### Float to Int


### PR DESCRIPTION
In Lesson 2, Data Types and Casting, while giving an example of casting floats from strings it mistakenly says:
```
console.log(numInt) // 9.81
```
where the correct code for output `9.81` would be:
```
console.log(numFloat) // 9.81
```