### PR TITLE
correction

### DIFF
--- a/18_Day_Promises/18_day_promises.md
+++ b/18_Day_Promises/18_day_promises.md
@@ -147,7 +147,7 @@ Let us another example when the promise is settled with reject.
 const doPromise = new Promise((resolve, reject) => {
   setTimeout(() => {
     const skills = ['HTML', 'CSS', 'JS']
-    if (skills.icludes('Node')) {
+    if (skills.includes('Node')) {
       resolve('fullstack developer')
     } else {
       reject('Something wrong has happened')


### PR DESCRIPTION
In lesson 18 there's a missing "n" in "icludes"

```js
// Promise
const doPromise = new Promise((resolve, reject) => {
  setTimeout(() => {
    const skills = ['HTML', 'CSS', 'JS']
    if (skills.icludes('Node')) {
      resolve('fullstack developer')
    } else {
      reject('Something wrong has happened')
    }
  }, 2000)
})

doPromise
  .then(result => {
    console.log(result)
  })
  .catch(error => console.error(error))
 ```
