### PR TITLE
Add missed parent class name in the inheritance syntax example

### DIFF
--- a/15_Day_Classes/15_day_classes.md
+++ b/15_Day_Classes/15_day_classes.md
@@ -555,7 +555,7 @@ Using inheritance we can access all the properties and the methods of the parent
 
 ```js
 // syntax
-class ChildClassName extends {
+class ChildClassName extends ParentClassName {
  // code goes here
 }
 ```


### PR DESCRIPTION
Day 15. Classes. There was missed parent class name in the inheritance syntax example