### PR TITLE
Punctuation error in exercise level 3 for 04_day_conditionals.md

### DIFF
--- a/04_Day_Conditionals/04_day_conditionals.md
+++ b/04_Day_Conditionals/04_day_conditionals.md
@@ -369,7 +369,7 @@ isRaining
     February has 28 days.
   ```
 
-1. Write a program which tells the number of days in a month, now consider leap year.
+2. Write a program which tells the number of days in a month, now consider leap year.
 
 
 🎉 CONGRATULATIONS ! 🎉


### PR DESCRIPTION
Punctuation error, double 1. instead of 1. and 2.