### PR TITLE
Correct the year on Day 3

### DIFF
--- a/03_Day_Booleans_operators_date/03_booleans_operators_date.md
+++ b/03_Day_Booleans_operators_date/03_booleans_operators_date.md
@@ -628,6 +628,6 @@ console.log(`${date}/${month}/${year} ${hours}:${minutes}`) // 4/1/2020 0:56
 ### Exercises: Level 3
 
 1. Create a human readable time format using the Date time object. The hour and the minute should be all the time two digits(7 hours should be 07 and 5 minutes should be 05 )
-   1. YYY-MM-DD HH:mm eg. 20120-01-02 07:05
+   1. YYYY-MM-DD HH:mm eg. 2020-01-02 07:05
 
 [<< Day 2](../02_Day_Data_types/02_day_data_types.md) | [Day 4 >>](../04_Day_Conditionals/04_day_conditionals.md)


### PR DESCRIPTION
Level 3 Excersise 1  contains a typo of the year which contains 5 digits so corrected it to 4 digits.