### PR TITLE
Update 05_day_arrays.md, fixed splice( ) in line number 525

### DIFF
--- a/05_Day_Arrays/05_day_arrays.md
+++ b/05_Day_Arrays/05_day_arrays.md
@@ -522,7 +522,7 @@ Splice: It takes three parameters:Starting position, number of times to be remov
 ```js
   const numbers = [1, 2, 3, 4, 5]
   numbers.splice()
-  console.log(numbers)                // -> remove all items
+  console.log(numbers)                // -> doesn't remove any item
 
 ```
 
@@ -535,7 +535,7 @@ Splice: It takes three parameters:Starting position, number of times to be remov
 ```js
   const numbers = [1, 2, 3, 4, 5, 6]
 	numbers.splice(3, 3, 7, 8, 9)
-  console.log(numbers.splice(3, 3, 7, 8, 9))  // -> [1, 2, 3, 7, 8, 9] //it removes three item and replace three items
+  console.log(numbers.splice(3, 3, 7, 8, 9))  // -> [1, 2, 3, 7, 8, 9] //it removes three item from index 3 and adds three items
 ```
 
 #### Adding item to an array using push


### PR DESCRIPTION
Fixed an error in the description of splice( ), which was wrongly written as splice( ) with no arguments removes all elements, but actually it's the opposite.