### PR TITLE
adjust radius value so that calculated areaOfCircle is correct

### DIFF
--- a/03_Day_Booleans_operators_date/03_booleans_operators_date.md
+++ b/03_Day_Booleans_operators_date/03_booleans_operators_date.md
@@ -146,7 +146,7 @@ console.log(sum, diff, mult, div, remainder, powerOf) // 7,1,12,1.33,1, 64
 
 ```js
 const PI = 3.14
-let radius = 100          // length in meter
+let radius = 10          // length in meter
 
 //Let us calculate area of a circle
 const areaOfCircle = PI * radius * radius


### PR DESCRIPTION
For variable `radius` value assigned is 10.
This variable is further used calculate area of circle using formula ` PI*radius*radius`. The result is stored in another variable called `areaOfCircle`. 
The result is logged as below 
`condole.log(areaOfCircle)  // 314 metres`
Since the value assigned for `radius` is 100, the `PI*radius*radius` results into 31400 metres. 
To fix this, I have adjusted `radius` value to 10. Now the result will be 314 metres.