### PR TITLE
deleted unnecessary codes from a example

### DIFF
--- a/10_Day_Sets_and_Maps/10_day_Sets_and_Maps.md
+++ b/10_Day_Sets_and_Maps/10_day_Sets_and_Maps.md
@@ -188,7 +188,6 @@ console.log(langSet) // Set(4) {"English", "Finnish", "French", "Spanish"}
 console.log(langSet.size) // 4
 
 const counts = []
-const count = {}
 
 for (const l of langSet) {
   const filteredLang = languages.filter((lng) => lng === l)


### PR DESCRIPTION
const languages = [
  'English',
  'Finnish',
  'English',
  'French',
  'Spanish',
  'English',
  'French',
]
const langSet = new Set(languages)
console.log(langSet) // Set(4) {"English", "Finnish", "French", "Spanish"}
console.log(langSet.size) // 4

const counts = []
const count = {}  // this code unnecessary and confused  

for (const l of langSet) {
  const filteredLang = languages.filter((lng) => lng === l)
  console.log(filteredLang) // ["English", "English", "English"]
  counts.push({ lang: l, count: filteredLang.length })
}
console.log(counts)